### PR TITLE
Testfix

### DIFF
--- a/arquillian-container-liferay/pom.xml
+++ b/arquillian-container-liferay/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<artifactId>arquillian-extension-liferay</artifactId>
 		<groupId>com.liferay.arquillian</groupId>
-		<version>1.0.0.Alpha1-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<groupId>com.liferay.arquillian</groupId>
 	<artifactId>arquillian-container-liferay</artifactId>
-	<version>1.0.0.Alpha1-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/arquillian-deployment-generator-bnd/pom.xml
+++ b/arquillian-deployment-generator-bnd/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <artifactId>arquillian-extension-liferay</artifactId>
         <groupId>com.liferay.arquillian</groupId>
-        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>arquillian-deployment-generator-bnd</artifactId>
     <groupId>com.liferay.arquillian</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <build>
 		<plugins>

--- a/arquillian-liferay-maven-extension/pom.xml
+++ b/arquillian-liferay-maven-extension/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>arquillian-liferay-maven-extension</artifactId>
   <name>Arquillian Maven Extension for Liferay</name>
   <description>The Deployment Scenario for Liferay Maven projects</description>
+  <version>1.0.0-SNAPSHOT</version>
 
   <dependencies>
 

--- a/arquillian-liferay-maven-extension/pom.xml
+++ b/arquillian-liferay-maven-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>arquillian-extension-liferay</artifactId>
     <groupId>com.liferay.arquillian</groupId>
-    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/arquillian-liferay-maven-extension/src/test/resources/settings.xml
+++ b/arquillian-liferay-maven-extension/src/test/resources/settings.xml
@@ -9,7 +9,7 @@
         <repository>
           <id>liferay-public-repository</id>
           <name>Liferay Repository</name>
-          <url>http://repository.liferay.com/nexus/content/groups/liferay-ce/</url>
+          <url>http://repository.liferay.com/nexus/content/groups/public/</url>
           <releases>
             <updatePolicy>never</updatePolicy>
           </releases>

--- a/arquillian-liferay-maven-extension/src/test/resources/settings.xml
+++ b/arquillian-liferay-maven-extension/src/test/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
-  xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"
+  xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <profiles>
     <profile>
       <repositories>

--- a/arquillian-liferay-maven-extension/src/test/resources/settings.xml
+++ b/arquillian-liferay-maven-extension/src/test/resources/settings.xml
@@ -18,18 +18,6 @@
           </snapshots>
         </repository>
 
-        <repository>
-          <id>jboss-public-repository</id>
-          <name>JBoss Repository</name>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-          <releases>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </repository>
-        
       </repositories>
 
       <id>arquillian-liferay-maven-ext</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.liferay.arquillian</groupId>
   <artifactId>arquillian-extension-liferay</artifactId>
-  <version>1.0.0.Alpha1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <scm>


### PR DESCRIPTION
Hey @csierra  I tried to build this on my local machine and I was getting the following error:

```
Jan 06, 2015 3:55:10 PM org.jboss.shrinkwrap.resolver.impl.maven.logging.LogTransferListener transferFailed
WARNING: Failed downloading com/liferay/portal/portal-web/6.2.1/portal-web-6.2.1.pom from http://repository.jboss.org/nexus/content/groups/public/. Reason: 
org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact com.liferay.portal:portal-web:pom:6.2.1 in jboss-public-repository (http://repository.jboss.org/nexus/content/groups/public)
```

Looks like the settings.xml that was used for adding the extra repos was given the embedded Aether client some trouble.  Simplifying things to just one repo seemed to do the trick for me.  