### PR TITLE
Update deployment generator to include maven pom dependencies in war.

### DIFF
--- a/arquillian-liferay-maven-extension/src/main/java/org/arquillian/liferay/maven/generator/MavenDeploymentScenarioGenerator.java
+++ b/arquillian-liferay-maven-extension/src/main/java/org/arquillian/liferay/maven/generator/MavenDeploymentScenarioGenerator.java
@@ -28,6 +28,8 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolverSystem;
 import org.jboss.shrinkwrap.resolver.api.maven.archive.importer.MavenImporter;
 import org.jboss.shrinkwrap.resolver.impl.maven.util.Validate;
 
@@ -109,6 +111,10 @@ public class MavenDeploymentScenarioGenerator
 			WebArchive archive =
 				ShrinkWrap.create(MavenImporter.class).loadPomFromFile(
 					pomFile).importBuildOutput().as(WebArchive.class);
+
+			MavenResolverSystem resolver = Maven.resolver();
+			archive.addAsLibraries(resolver.loadPomFromFile(pomFile)
+					.importCompileAndRuntimeDependencies().resolve().withTransitivity().asFile());
 
 			DeploymentDescription deploymentDescription =
 				new DeploymentDescription("_DEFAULT", archive);


### PR DESCRIPTION
In current version of plugin the pom dependencies of plugins are not included in the deployed war.
This pull request will make arquillian include all pom dependencies.
# Example
## Pom.xml

``` <dependency>
      <groupId>org.apache.commons</groupId>
      <artifactId>commons-lang3</artifactId>
      <version>3.4</version>
    </dependency>
```
## Test class

```
    @Test
    public void testPluginType() {
        String termsOfUseRequired = PropsUtil.get("terms.of.use.required");
        System.out.println("Default company Id : " + PortalUtil.getDefaultCompanyId());

        System.out.println(StringUtils.isEmpty(termsOfUseRequired));

        assertEquals("false", termsOfUseRequired);
    }
```
## Result

```
java.lang.NoClassDefFoundError: org/apache/commons/lang/StringUtils
    at com.example.plugins.SimpleHookTest.testPluginType(SimpleHookTest.java:42)
```
